### PR TITLE
Fixed typo in the SimpleConfiguredActorEmail trait. Close #11.

### DIFF
--- a/javamail/src/main/scala/org/eigengo/akkaextras/javamail/actor.scala
+++ b/javamail/src/main/scala/org/eigengo/akkaextras/javamail/actor.scala
@@ -10,7 +10,7 @@ import javax.mail.internet.MimeMessage
  * system.actorOf(new EmailActor with SimpleConfiguredActorEmail)
  * }}}
  */
-trait SimpleConfgiruedActorEmail extends SimpleUnconfiguredEmail with ConfigEmailConfiguration {
+trait SimpleConfiguredActorEmail extends SimpleUnconfiguredEmail with ConfigEmailConfiguration {
   this: Actor =>
 
   def config = context.system.settings.config


### PR DESCRIPTION
Sorry. Won't happen again.
