### PR TITLE
Fixed the double quote issue

### DIFF
--- a/javamail/src/main/scala/org/eigengo/akkaextras/javamail/transport.scala
+++ b/javamail/src/main/scala/org/eigengo/akkaextras/javamail/transport.scala
@@ -58,13 +58,14 @@ trait ConfigEmailConfiguration extends EmailConfiguration {
 
   }
 
+
   private def buildMailProperties(): java.util.Properties = {
     val props = new Properties()
     if (config.hasPath("akka-extras.javamail.properties")) {
       val properties = config.getConfig("akka-extras.javamail.properties")
       import scala.collection.JavaConversions._
       properties.entrySet().foreach { entry =>
-        props.put(entry.getKey, entry.getValue.render())
+        props.put(entry.getKey, entry.getValue.render().replaceAll("\"",""))
       }
     }
     props


### PR DESCRIPTION
Bear in mind that, even though the replaceAll trick is a "partial function" in the solution space, 'cause it doesn't handle cases where we have genuine quotes in the middle, I think it's all we need here, because we are reading just from `javamail.properties`.

This essentially means that we never hit the case where we are incorrectly stripping genuine quotes not at the beginning or at the end. In case we have corner case I haven't thought of, (e.g. the user misuse the app and put username and password there, where both can have quotes?) than we need a more robust solution. I already have a prototype for that, so just keep me posted.

For now the benefit of this solution is that is really cheap in terms of visual clutter.
